### PR TITLE
feat: добавлена возможность отключать фоновое слежение за логами

### DIFF
--- a/LogViewer/SettingsWindow.xaml
+++ b/LogViewer/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="LogViewer.SettingsWindow"
+<Window x:Class="LogViewer.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -36,7 +36,14 @@
       VerticalScrollBarVisibility="Visible"
       Text="{Binding Path=(local:SettingsWindow.WhitelistLogs), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <CheckBox Grid.Row="4" Margin="0,5,0,0" x:Name="AssociateLogFileCheckBox" IsThreeState="False" Height="20" Content="associate *.log file with application" IsChecked="{Binding Path=(local:SettingsWindow.AssociateLogFile), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+    <Grid Grid.Row="4" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Stretch">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <CheckBox Grid.Column="0" Margin="0,5,0,0" x:Name="AssociateLogFileCheckBox" IsThreeState="False" Height="20" Content="associate *.log file with application" IsChecked="{Binding Path=(local:SettingsWindow.AssociateLogFile), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+      <CheckBox Grid.Column="1" Margin="0,5,0,0" x:Name="UseBackgroundNotificationCheckBox" IsThreeState="False" Height="20" Content="use background" IsChecked="{Binding Path=(local:SettingsWindow.UseBackgroundNotification), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+    </Grid>
 
     <WrapPanel Grid.Row="5" HorizontalAlignment="Right" Margin="0,0,0,0" VerticalAlignment="Bottom">
       <Button IsDefault="False" Click="Accept_Click" MinWidth="60" Margin="0,0,10,0">OK</Button>

--- a/LogViewer/SettingsWindow.xaml.cs
+++ b/LogViewer/SettingsWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
 using System.Collections.Generic;
@@ -16,12 +16,14 @@ namespace LogViewer
     public static bool AssociateLogFile { get; set; }
     public static bool AssociateLogFileChanged { get { return associateLogFileOldValue != AssociateLogFile; }  }
     private static bool associateLogFileOldValue { get; set; }
+    public static bool UseBackgroundNotification { get; set; }
 
     private const string DefaultLogPath = @"D:\Projects\master\Logs";
     private const string RegKey = @"SOFTWARE\JsonLogViewerSettings";
     private const string LogsPathKey = "LogsPath";
     private const string WhitelistKey = "WhiteList";
     private const string AssociateLogFileKey = "AssociateLogFile";
+    private const string UseBackgroundNotificationKey = "UseBackgroundNotification";
     private static readonly List<string> DefaultListLogs = new List<string>
     {
       "${machinename}.WebServer.${shortdate}",
@@ -60,6 +62,7 @@ namespace LogViewer
         key.SetValue(LogsPathKey, dialog.LogsPathTextBox.Text);
         key.SetValue(WhitelistKey, dialog.WhiteListTextBox.Text);
         key.SetValue(AssociateLogFileKey, dialog.AssociateLogFileCheckBox.IsChecked);
+        key.SetValue(UseBackgroundNotificationKey, dialog.UseBackgroundNotificationCheckBox.IsChecked);
         key.Close();
       }
 
@@ -76,6 +79,8 @@ namespace LogViewer
 
       AssociateLogFile = Convert.ToBoolean(key.GetValue(AssociateLogFileKey, false));
       associateLogFileOldValue = AssociateLogFile;
+
+      UseBackgroundNotification = Convert.ToBoolean(key.GetValue(UseBackgroundNotificationKey, false));
 
       key.Close();
     }


### PR DESCRIPTION
Решает две проблемы:
1. После первого открытия файла лога он остается заблокированным до тех пор, пока не закроешь LogViewer. Это не дает, например, обновить файл лога скопировав его с другой машины. Приходится закрывать, открывать заново.
2. Фоновое слежение за кучкой логов - это довольно специфичный редкий кейс. В большинстве случаев выскакивающие сообщения скорее мешают, чем помогают. Приходится блокировать их на уровне Windows. А обратно их там включить - так просто и не найдешь как. В результате, по факту, возможность не используется. А какую-то лишнюю нагрузку создает.