### PR TITLE
Rework file stream

### DIFF
--- a/LogReader/LogWatcher.cs
+++ b/LogReader/LogWatcher.cs
@@ -1,120 +1,201 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Timers;
 
 namespace LogReader
 {
-  /// <summary>
-  /// Наблюдатель за изменениями в лог файле.
-  /// </summary>
-  public class LogWatcher : IDisposable
-  {
-    public bool IsWatching { get; private set; }
-
-    public delegate void BlockNewLinesHandler(List<string> lines, bool isEndFile, double progress);
-    public event BlockNewLinesHandler BlockNewLines;
-
-    public delegate void FileReCreatedHandler();
-    public event FileReCreatedHandler FileReCreated;
-
-    private FileStream fileStream;
-    private StreamReader streamReader;
-    private Timer timer;
-    private readonly object readLock = new object();
-    private long fileLength;
-
-    private const int LineBlockSize = 500;
-
-    public LogWatcher(string filePath)
+    /// <summary>
+    /// Наблюдатель за изменениями в лог файле.
+    /// </summary>
+    public class LogWatcher : IDisposable
     {
-      fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-      streamReader = new StreamReader(fileStream);
-      fileLength = streamReader.BaseStream.Length;
-    }
+        public bool IsWatching { get; private set; }
 
-    public void StartWatch(int period)
-    {
-      if (IsWatching)
-        throw new Exception("Log file already watching");
+        public delegate void BlockNewLinesHandler(List<string> lines, bool isEndFile, double progress);
+        public event BlockNewLinesHandler BlockNewLines;
 
-      IsWatching = true;
+        public delegate void FileReCreatedHandler();
+        public event FileReCreatedHandler FileReCreated;
 
-      timer = new Timer();
-      timer.AutoReset = false;
-      timer.Interval = period;
-      timer.Elapsed += OnTimedEvent;
-      timer.Start();
-    }
+        //private FileStream fileStream;
+        //private StreamReader streamReader;
+        private Timer timer;
+        private FileSystemWatcher fileSystemWatcher;
+        private readonly object readLock = new object();
+        private long fileLength;
+        private string filePath;
 
-    public void ReadToEndLine()
-    {
-      lock (readLock)
-      {
-        var current_length = streamReader.BaseStream.Length;
 
-        if (current_length < fileLength)
+        private const int LineBlockSize = 500;
+
+        public LogWatcher(string filePath)
         {
-          streamReader.DiscardBufferedData();
-          streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
-          FileReCreated?.Invoke();
-        }
-
-        fileLength = current_length;
-        string line;
-        List<string> lines = new List<string>();
-
-        while (streamReader != null && (line = streamReader.ReadLine()) != null)
-        {
-          if (!String.IsNullOrEmpty(line))
-          {
-            lines.Add(line);
-
-            if (lines.Count >= LineBlockSize)
+            this.filePath = filePath;
+            //fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            //streamReader = new StreamReader(fileStream);
+            //fileLength = streamReader.BaseStream.Length;
+            var qq = Path.GetDirectoryName(this.filePath);
+            var tt = Path.GetFileName(this.filePath);
+            fileSystemWatcher = new FileSystemWatcher(Path.GetDirectoryName(this.filePath))
             {
-              InvokeBlockNewLinesEvent(lines);
-              lines.Clear();
-            }
-          }
+                NotifyFilter = NotifyFilters.Attributes
+                                | NotifyFilters.CreationTime
+                                | NotifyFilters.DirectoryName
+                                | NotifyFilters.FileName
+                                | NotifyFilters.LastAccess
+                                | NotifyFilters.LastWrite
+                                | NotifyFilters.Security
+                                | NotifyFilters.Size
+            };
+            fileSystemWatcher.Filter = Path.GetFileName(this.filePath);
+            fileSystemWatcher.IncludeSubdirectories = true;
+            fileSystemWatcher.EnableRaisingEvents = true;
+            fileSystemWatcher.Changed += OnChange;
+            fileLength = 0;
         }
 
-        if (lines.Count > 0)
-          InvokeBlockNewLinesEvent(lines);
-      }
+        public void StartWatch(int period)
+        {
+            if (IsWatching)
+                throw new Exception("Log file already watching");
+
+            IsWatching = true;
+
+            timer = new Timer();
+            timer.AutoReset = false;
+            timer.Interval = period;
+            timer.Elapsed += OnTimedEvent;
+            timer.Start();
+        }
+        public void StartFileSystemWatcher()
+        {
+            if (IsWatching)
+                throw new Exception("Log file already watching");
+
+            IsWatching = true;
+        }
+
+        public void ReadToEndLine()
+        {
+            lock (readLock)
+            {
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var streamReader = new StreamReader(fileStream);
+                var current_length = streamReader.BaseStream.Length;
+
+                if (current_length < fileLength)
+                {
+                    streamReader.DiscardBufferedData();
+                    streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
+                    FileReCreated?.Invoke();
+                }
+
+                fileLength = current_length;
+                string line;
+                List<string> lines = new List<string>();
+
+                while (streamReader != null && (line = streamReader.ReadLine()) != null)
+                {
+                    if (!String.IsNullOrEmpty(line))
+                    {
+                        lines.Add(line);
+
+                        if (lines.Count >= LineBlockSize)
+                        {
+                            InvokeBlockNewLinesEvent(lines, streamReader);
+                            lines.Clear();
+                        }
+                    }
+                }
+
+                if (lines.Count > 0)
+                    InvokeBlockNewLinesEvent(lines, streamReader);
+            }
+        }
+        public void ReadToEndLineWithoutLock()
+        {
+            lock (readLock)
+            {
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var streamReader = new StreamReader(fileStream);
+                var current_length = streamReader.BaseStream.Length;
+
+                if (current_length < fileLength)
+                {
+                    streamReader.DiscardBufferedData();
+                    streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
+                    FileReCreated?.Invoke();
+                }
+
+
+                string line;
+                List<string> lines = new List<string>();
+                streamReader.BaseStream.Seek(fileLength == 0 ? fileLength : fileLength -2, SeekOrigin.Begin);
+                fileLength = current_length;
+                while (streamReader != null && (line = streamReader.ReadLine()) != null)
+                {
+                    if (!String.IsNullOrEmpty(line))
+                    {
+                        lines.Add(line);
+
+                        if (lines.Count >= LineBlockSize)
+                        {
+                            InvokeBlockNewLinesEvent(lines, streamReader);
+                            lines.Clear();
+                        }
+                    }
+                }
+
+                if (lines.Count > 0)
+                    InvokeBlockNewLinesEvent(lines, streamReader);
+
+
+            }
+        }
+
+        private void OnTimedEvent(Object source, ElapsedEventArgs e)
+        {
+            ReadToEndLineWithoutLock();
+            timer.Start();
+        }
+        private void OnChange(object sender, FileSystemEventArgs e)
+        {
+            ReadToEndLineWithoutLock();
+        }
+
+        private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
+        {
+            var progress = fileLength == 0 ? 100 : 100 * streamReader.BaseStream.Position / fileLength;
+            BlockNewLines?.Invoke(lines, streamReader.Peek() == -1, progress);
+        }
+
+        public void Dispose()
+        {
+            if (timer != null)
+            {
+                timer.Dispose();
+                timer = null;
+            }
+            if (fileSystemWatcher != null)
+            {
+                fileSystemWatcher.Dispose();
+                fileSystemWatcher = null;
+            }
+
+            //if (streamReader != null)
+            //{
+            //    streamReader.Dispose();
+            //    streamReader = null;
+            //}
+
+            //if (fileStream != null)
+            //{
+            //    fileStream.Dispose();
+            //    fileStream = null;
+            //}
+        }
+
     }
-
-    private void OnTimedEvent(Object source, ElapsedEventArgs e)
-    {
-      ReadToEndLine();
-      timer.Start();
-    }
-
-    private void InvokeBlockNewLinesEvent(List<string> lines)
-    {
-      var progress = fileLength == 0 ? 100 : 100 * streamReader.BaseStream.Position / fileLength;
-      BlockNewLines?.Invoke(lines, streamReader.Peek() == -1, progress);
-    }
-
-    public void Dispose()
-    {
-      if (timer != null)
-      {
-        timer.Dispose();
-        timer = null;
-      }
-
-      if (streamReader != null)
-      {
-        streamReader.Dispose();
-        streamReader = null;
-      }
-
-      if (fileStream != null)
-      {
-        fileStream.Dispose();
-        fileStream = null;
-      }
-    }
-
-  }
 }

--- a/LogReader/LogWatcher.cs
+++ b/LogReader/LogWatcher.cs
@@ -13,31 +13,30 @@ namespace LogReader
     {
         public bool IsWatching { get; private set; }
 
-        public delegate void BlockNewLinesHandler(List<string> lines, bool isEndFile, double progress);
+        public delegate void BlockNewLinesHandler(List<string> lines, double progress);
         public event BlockNewLinesHandler BlockNewLines;
 
         public delegate void FileReCreatedHandler();
         public event FileReCreatedHandler FileReCreated;
 
-        //private FileStream fileStream;
-        //private StreamReader streamReader;
-        private Timer timer;
         private FileSystemWatcher fileSystemWatcher;
         private readonly object readLock = new object();
         private long fileLength;
+        private long position;
         private string filePath;
 
-
+        /// <summary>
+        /// Кол-во max строк для блока записи.
+        /// </summary>
         private const int LineBlockSize = 500;
 
+        /// <summary>
+        /// ctor с созданием наблюдателем за файлом по указанному пути. Тригер на изменение файла.
+        /// </summary>
+        /// <param name="filePath">Путь до файла.</param>
         public LogWatcher(string filePath)
         {
             this.filePath = filePath;
-            //fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            //streamReader = new StreamReader(fileStream);
-            //fileLength = streamReader.BaseStream.Length;
-            var qq = Path.GetDirectoryName(this.filePath);
-            var tt = Path.GetFileName(this.filePath);
             fileSystemWatcher = new FileSystemWatcher(Path.GetDirectoryName(this.filePath))
             {
                 NotifyFilter = NotifyFilters.Attributes
@@ -56,19 +55,10 @@ namespace LogReader
             fileLength = 0;
         }
 
-        public void StartWatch(int period)
-        {
-            if (IsWatching)
-                throw new Exception("Log file already watching");
-
-            IsWatching = true;
-
-            timer = new Timer();
-            timer.AutoReset = false;
-            timer.Interval = period;
-            timer.Elapsed += OnTimedEvent;
-            timer.Start();
-        }
+        /// <summary>
+        /// При возможном сбое повторного просмотра файла - вылетает ошибка.
+        /// </summary>
+        /// <exception cref="Exception">Log file already watching</exception>
         public void StartFileSystemWatcher()
         {
             if (IsWatching)
@@ -77,11 +67,14 @@ namespace LogReader
             IsWatching = true;
         }
 
+        /// <summary>
+        /// Чтение файла. При повторном срабатывании читает файл с прошлого места окончания чтения.
+        /// </summary>
         public void ReadToEndLine()
         {
             lock (readLock)
             {
-                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var fileStream = new FileStream(this.filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var streamReader = new StreamReader(fileStream);
                 var current_length = streamReader.BaseStream.Length;
 
@@ -89,50 +82,14 @@ namespace LogReader
                 {
                     streamReader.DiscardBufferedData();
                     streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
-                    FileReCreated?.Invoke();
-                }
-
-                fileLength = current_length;
-                string line;
-                List<string> lines = new List<string>();
-
-                while (streamReader != null && (line = streamReader.ReadLine()) != null)
-                {
-                    if (!String.IsNullOrEmpty(line))
-                    {
-                        lines.Add(line);
-
-                        if (lines.Count >= LineBlockSize)
-                        {
-                            InvokeBlockNewLinesEvent(lines, streamReader);
-                            lines.Clear();
-                        }
-                    }
-                }
-
-                if (lines.Count > 0)
-                    InvokeBlockNewLinesEvent(lines, streamReader);
-            }
-        }
-        public void ReadToEndLineWithoutLock()
-        {
-            lock (readLock)
-            {
-                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var streamReader = new StreamReader(fileStream);
-                var current_length = streamReader.BaseStream.Length;
-
-                if (current_length < fileLength)
-                {
-                    streamReader.DiscardBufferedData();
-                    streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
+                    this.position = 0;
                     FileReCreated?.Invoke();
                 }
 
 
                 string line;
                 List<string> lines = new List<string>();
-                streamReader.BaseStream.Seek(fileLength == 0 ? fileLength : fileLength -2, SeekOrigin.Begin);
+                streamReader.BaseStream.Position = this.position;
                 fileLength = current_length;
                 while (streamReader != null && (line = streamReader.ReadLine()) != null)
                 {
@@ -150,51 +107,41 @@ namespace LogReader
 
                 if (lines.Count > 0)
                     InvokeBlockNewLinesEvent(lines, streamReader);
-
+                this.position = streamReader.BaseStream.Position;
 
             }
         }
 
-        private void OnTimedEvent(Object source, ElapsedEventArgs e)
-        {
-            ReadToEndLineWithoutLock();
-            timer.Start();
-        }
+        /// <summary>
+        /// Event на изменение файла.
+        /// </summary>
         private void OnChange(object sender, FileSystemEventArgs e)
         {
-            ReadToEndLineWithoutLock();
+            ReadToEndLine();
         }
 
+        /// <summary>
+        /// Заполнение прогресса.
+        /// Вызов делегата BlockNewLines.
+        /// </summary>
+        /// <param name="lines">Новые прочитанные строки.</param>
+        /// <param name="streamReader">Экземпляр reader для работы в обработчике.</param>
         private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
         {
             var progress = fileLength == 0 ? 100 : 100 * streamReader.BaseStream.Position / fileLength;
-            BlockNewLines?.Invoke(lines, streamReader.Peek() == -1, progress);
+            BlockNewLines?.Invoke(lines, progress);
         }
 
+        /// <summary>
+        /// Обработчик закрытияй файлов.
+        /// </summary>
         public void Dispose()
         {
-            if (timer != null)
-            {
-                timer.Dispose();
-                timer = null;
-            }
             if (fileSystemWatcher != null)
             {
                 fileSystemWatcher.Dispose();
                 fileSystemWatcher = null;
             }
-
-            //if (streamReader != null)
-            //{
-            //    streamReader.Dispose();
-            //    streamReader = null;
-            //}
-
-            //if (fileStream != null)
-            //{
-            //    fileStream.Dispose();
-            //    fileStream = null;
-            //}
         }
 
     }

--- a/LogReader/LogWatcher.cs
+++ b/LogReader/LogWatcher.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Timers;
 
 namespace LogReader
@@ -24,6 +27,7 @@ namespace LogReader
         private long fileLength;
         private long position;
         private string filePath;
+        private const int GridUpdateTimer = 1000;
 
         /// <summary>
         /// Кол-во max строк для блока записи.
@@ -76,8 +80,7 @@ namespace LogReader
             {
                 using var fileStream = new FileStream(this.filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var streamReader = new StreamReader(fileStream);
-                var current_length = streamReader.BaseStream.Length;
-
+                long current_length = streamReader.BaseStream.Length;
                 if (current_length < fileLength)
                 {
                     streamReader.DiscardBufferedData();
@@ -117,6 +120,7 @@ namespace LogReader
         /// </summary>
         private void OnChange(object sender, FileSystemEventArgs e)
         {
+            Thread.Sleep(GridUpdateTimer);
             ReadToEndLine();
         }
 

--- a/LogReader/LogWatcher.cs
+++ b/LogReader/LogWatcher.cs
@@ -131,13 +131,13 @@ namespace LogReader
             }
         }
 
-            /// <summary>
-            /// Заполнение прогресса.
-            /// Вызов делегата BlockNewLines.
-            /// </summary>
-            /// <param name="lines">Новые прочитанные строки.</param>
-            /// <param name="streamReader">Экземпляр reader для работы в обработчике.</param>
-            private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
+        /// <summary>
+        /// Заполнение прогресса.
+        /// Вызов делегата BlockNewLines.
+        /// </summary>
+        /// <param name="lines">Новые прочитанные строки.</param>
+        /// <param name="streamReader">Экземпляр reader для работы в обработчике.</param>
+        private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
         {
             var progress = fileLength == 0 ? 100 : 100 * streamReader.BaseStream.Position / fileLength;
             BlockNewLines?.Invoke(lines, progress);

--- a/LogReader/LogWatcher.cs
+++ b/LogReader/LogWatcher.cs
@@ -28,6 +28,7 @@ namespace LogReader
         private long position;
         private string filePath;
         private const int GridUpdateTimer = 1000;
+        private DateTime lastRead = DateTime.MinValue;
 
         /// <summary>
         /// Кол-во max строк для блока записи.
@@ -120,17 +121,23 @@ namespace LogReader
         /// </summary>
         private void OnChange(object sender, FileSystemEventArgs e)
         {
-            Thread.Sleep(GridUpdateTimer);
-            ReadToEndLine();
+            DateTime lastWriteTime = File.GetLastWriteTime(this.filePath);
+            if (lastWriteTime != lastRead)
+            {
+                Thread.Sleep(GridUpdateTimer);
+                ReadToEndLine();
+                lastRead = lastWriteTime;
+
+            }
         }
 
-        /// <summary>
-        /// Заполнение прогресса.
-        /// Вызов делегата BlockNewLines.
-        /// </summary>
-        /// <param name="lines">Новые прочитанные строки.</param>
-        /// <param name="streamReader">Экземпляр reader для работы в обработчике.</param>
-        private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
+            /// <summary>
+            /// Заполнение прогресса.
+            /// Вызов делегата BlockNewLines.
+            /// </summary>
+            /// <param name="lines">Новые прочитанные строки.</param>
+            /// <param name="streamReader">Экземпляр reader для работы в обработчике.</param>
+            private void InvokeBlockNewLinesEvent(List<string> lines, StreamReader streamReader)
         {
             var progress = fileLength == 0 ? 100 : 100 * streamReader.BaseStream.Position / fileLength;
             BlockNewLines?.Invoke(lines, progress);

--- a/LogViewer/LogHandler.cs
+++ b/LogViewer/LogHandler.cs
@@ -13,7 +13,6 @@ namespace LogViewer
   {
     public const string LogLevelError = "Error";
     private const int NotificationTextMaxLength = 200;
-    private const int WatchPeriod = 3000;
 
     private readonly string filePath;
     private readonly Uri icon;
@@ -27,13 +26,12 @@ namespace LogViewer
       fileName = Path.GetFileName(filePath);
 
       watcher = new LogWatcher(filePath);
-      watcher.ReadToEndLineWithoutLock();
+      watcher.ReadToEndLine();
       watcher.BlockNewLines += OnBlockNewLines;
-      watcher.StartWatch(WatchPeriod);
       watcher.StartFileSystemWatcher();
     }
 
-    private void OnBlockNewLines(List<string> lines, bool isEndFile, double progress)
+    private void OnBlockNewLines(List<string> lines, double progress)
     {
       if (!watcher.IsWatching)
         return;

--- a/LogViewer/LogHandler.cs
+++ b/LogViewer/LogHandler.cs
@@ -13,6 +13,7 @@ namespace LogViewer
   {
     public const string LogLevelError = "Error";
     private const int NotificationTextMaxLength = 200;
+    private const int WatchPeriod = 3000;
 
     private readonly string filePath;
     private readonly Uri icon;
@@ -28,7 +29,7 @@ namespace LogViewer
       watcher = new LogWatcher(filePath);
       watcher.ReadToEndLine();
       watcher.BlockNewLines += OnBlockNewLines;
-      watcher.StartFileSystemWatcher();
+      watcher.StartWatch(WatchPeriod);
     }
 
     private void OnBlockNewLines(List<string> lines, double progress)

--- a/LogViewer/LogHandler.cs
+++ b/LogViewer/LogHandler.cs
@@ -27,9 +27,10 @@ namespace LogViewer
       fileName = Path.GetFileName(filePath);
 
       watcher = new LogWatcher(filePath);
-      watcher.ReadToEndLine();
+      watcher.ReadToEndLineWithoutLock();
       watcher.BlockNewLines += OnBlockNewLines;
       watcher.StartWatch(WatchPeriod);
+      watcher.StartFileSystemWatcher();
     }
 
     private void OnBlockNewLines(List<string> lines, bool isEndFile, double progress)

--- a/LogViewer/MainWindow.xaml.cs
+++ b/LogViewer/MainWindow.xaml.cs
@@ -41,8 +41,6 @@ namespace LogViewer
 
     private const string IconFileName = "horse.png";
 
-    private const int GridUpdatePeriod = 1000;
-
     // UseRegex is binding proprety
     public bool UseRegex { get; set; }
 

--- a/LogViewer/MainWindow.xaml.cs
+++ b/LogViewer/MainWindow.xaml.cs
@@ -40,8 +40,9 @@ namespace LogViewer
     private const string All = "All";
 
     private const string IconFileName = "horse.png";
+    private const int GridUpdatePeriod = 1000;
 
-    // UseRegex is binding proprety
+        // UseRegex is binding proprety
     public bool UseRegex { get; set; }
 
     private readonly List<LogHandler> logHandlers = new List<LogHandler>();
@@ -306,7 +307,7 @@ namespace LogViewer
         if(logLines.Any())
             LogsGrid.ScrollIntoView(logLines.Last());
 
-        logWatcher.StartFileSystemWatcher();
+        logWatcher.StartWatch(GridUpdatePeriod);
 
         var tenants = logLines.Where(l => !string.IsNullOrEmpty(l.Tenant)).Select(l => l.Tenant).Distinct().OrderBy(l => l);
 

--- a/LogViewer/MainWindow.xaml.cs
+++ b/LogViewer/MainWindow.xaml.cs
@@ -295,12 +295,13 @@ namespace LogViewer
 
         logWatcher = new LogWatcher(fullPath);
         logWatcher.BlockNewLines += OnBlockNewLines;
-        logWatcher.FileReCreated += OnFileReCreated;
-        logWatcher.ReadToEndLine();
+        //logWatcher.FileReCreated += OnFileReCreated;
+        logWatcher.ReadToEndLineWithoutLock();
         LogsGrid.ItemsSource = logLines;
         LogsGrid.ScrollIntoView(logLines.Last());
 
-        logWatcher.StartWatch(GridUpdatePeriod);
+        //logWatcher.StartWatch(GridUpdatePeriod);
+        logWatcher.StartFileSystemWatcher();
 
         var tenants = logLines.Where(l => !string.IsNullOrEmpty(l.Tenant)).Select(l => l.Tenant).Distinct().OrderBy(l => l);
 
@@ -372,7 +373,7 @@ namespace LogViewer
       Application.Current.Dispatcher.Invoke(
         new Action(() =>
         {
-          if (LoadBar.Visibility == Visibility.Visible && LoadBar.Value != progress)
+            if (LoadBar.Visibility == Visibility.Visible && LoadBar.Value != progress)
             LoadBar.Dispatcher.Invoke(() => LoadBar.Value = progress, DispatcherPriority.Background);
 
           var scrollToEnd = false;


### PR DESCRIPTION
Убрал таймер - отслеживаем по изменению файла.
Поменял работу StreamReader. Было - открытие файла в конструкторе, закрытие при выходе. Сейчас connection создается каждый раз, когда нужно  прочитать файл. Тем самым ушли от критической ошибки загрязнения памяти.
Добавил комментарии.
Отступы поменялись (по сочетанию cntr +k+d).

